### PR TITLE
Bring basic compilation of NCrystal lib to Windows using MinGW compiler

### DIFF
--- a/ncrystal_core/src/NCFileUtils.cc
+++ b/ncrystal_core/src/NCFileUtils.cc
@@ -145,8 +145,8 @@ NC::VectS NC::ncglob(const std::string& pattern) {
 std::string NC::ncgetcwd() {
     char buff[MAX_PATH];
     GetModuleFileName( NULL, buff, MAX_PATH );
-    string::size_type position = string( buff ).find_last_of( "\\/" );
-    return string( buff ).substr( 0, position);
+    std::string::size_type position = std::string( buff ).find_last_of( "\\/" );
+    return std::string( buff ).substr( 0, position);
 }
 #else
 //POSIX globbing:

--- a/ncrystal_core/src/NCMem.cc
+++ b/ncrystal_core/src/NCMem.cc
@@ -76,6 +76,9 @@ void * NC::detail::bigAlignedAlloc( std::size_t alignment, std::size_t size )
   //    result = std::aligned_alloc(alignment,size);
 
   //roundToNextMultiple since that is what the aligned_alloc function expects.
+#ifdef WIN32
+#define aligned_alloc _aligned_malloc
+#endif
   result = aligned_alloc(alignment,detail::roundToNextMultiple( size, alignment ));
 #endif
   if ( result == nullptr ) {


### PR DESCRIPTION
Half-baked, but basic compilation archived using
* conda-provided cmake and ninja
* MinGW 11.2 from https://winlibs.com/ (what conda provides is too old...)

Recipe for lib build
* `cmake -G "Ninja" -DDISABLE_DYNLOAD=ON -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=c:/mcstas-3.2beta5/ ..`
* `cmake --build .`
* `ninja install`

Hard-coded dependency line for `NCrystal_sample.comp`
* `DEPENDENCY "-Wl,-rpath,C:\mcstas-3.2beta5\lib -LC:\mcstas-3.2beta5\lib -lNCrystal -IC:\mcstas-3.2beta5\include"`

Still a runtime error though (sorry, can't copy-paste the actual error message):
![Screenshot 2022-11-07 at 21 18 59](https://user-images.githubusercontent.com/8593355/200407015-18f5fcb9-bd41-43ce-83ff-67af2454e489.png)



