### PR TITLE
fix run-name bug when deploying to testpypi

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,5 +1,5 @@
 name: Publish to PyPI
-run-name: Publish to ${{inputs.TEST && 'Test' || ''}}PyPI
+run-name: Publish to ${{inputs.ENVIRONMENT=='testpypi' && 'Test' || ''}}PyPI ${{ inputs.REF && format('({0})', inputs.REF) }}
 
 on:
   push:


### PR DESCRIPTION
When manually triggering the workflow, there is an option to deploy to _TestPyPI_ by selecting the _testpypi_ environment, in which case the run-name should be 'Publish to TestPyPI', not 'Publish to PyPI'. Erroneously this is controlled by the old TEST input var, not the new ENVIRONMENT env var.

In addition to fixing this bug, this change includes adding the REF (tag/branch) input var in parentheses at the end of the run-name, in case of manual triggering. (For workflow runs triggered by push-tag events, the tag is indicated anyway.)