### PR TITLE
added importlib_metadata as build requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ requires = [
     "setuptools>=42",
     "scikit-build>=0.13",
     "cmake>=3.18",
-    "numpy"
+    "numpy",
+    "importlib_metadata"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Added importlib_metadata as build requirement to fix failing cp37-* wheel builds