### PR TITLE
disable building wheels for pypy, cpython 3.6 and 3.7

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -26,5 +26,6 @@ jobs:
       REF: ${{ inputs.REF || github.ref_name }}
       DO_DEPLOY: ${{ !inputs.BUILD_ONLY }}
       ENVIRONMENT: ${{ inputs.ENVIRONMENT || 'pypi' }}
+      CIBW_SKIP: pp* cp36-* cp37-* cp313-*
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -26,6 +26,6 @@ jobs:
       REF: ${{ inputs.REF || github.ref_name }}
       DO_DEPLOY: ${{ !inputs.BUILD_ONLY }}
       ENVIRONMENT: ${{ inputs.ENVIRONMENT || 'pypi' }}
-      CIBW_SKIP: pp* cp36-* cp37-* cp313-*
+      CIBW_SKIP: pp* cp36-* cp37-*
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Getting use of the [newly added](https://github.com/mctools/mctools_actions/commit/7e93c0649655b9cbd4606abda2be14c1271880f5) `CIBW_SKIP` input option in the _pypy_deploy_ workflow to skip building wheel files for CPython 3.6, 3.7, and 3.13. (Not building PyPy wheel files has always been the default.)

We could make CIBW_SKIP an input option for workflow dispatch, but it seems unlikely for me that we would want to manually edit it.

Once the Python 3.13 CI tests are passing, we could remove `cp313-*` from the filter patterns to enable building and deploying wheel files for the new Python version. 